### PR TITLE
feat: ログインコントローラにlogged_in?を付与してみる

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,6 @@ class ApplicationController < ActionController::Base
   private
 
   def authenticate
-    rodauth.require_authentication # redirect to login page if not authenticated
+    rodauth.require_authentication unless rodauth.logged_in? # redirect to login page if not authenticated
   end
 end


### PR DESCRIPTION
挙動としてはループのまま変化なし。しかし、before_actionをコメントアウトするとログイン画面に正常に遷移する